### PR TITLE
Restore the SIGINT default signal handler

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,11 @@ Release History
 Unreleased
 ++++++++++
 
+**Fixes**
+
+* Allow to use Ctrl-c to stop anthem.
+
+
 0.2.0 (2016-07-22)
 ++++++++++++++++++
 

--- a/anthem/__init__.py
+++ b/anthem/__init__.py
@@ -5,4 +5,4 @@
 __version__ = "0.2.0"
 
 # publish the decorator so we can use 'anthem.log'
-from output import log
+from output import log  # noqa

--- a/anthem/cli.py
+++ b/anthem/cli.py
@@ -7,6 +7,7 @@ from __future__ import print_function
 import argparse
 import code
 import importlib
+import signal
 
 from contextlib import contextmanager
 
@@ -92,6 +93,11 @@ class Context(object):
                 "-d or an Odoo configuration file)"
             )
         openerp.service.server.start(preload=[], stop=True)
+
+        # openerp.service.server.start() modifies the SIGINT signal by its own
+        # one which in fact prevents us to stop anthem with Ctrl-c.
+        # Restore the default one.
+        signal.signal(signal.SIGINT, signal.default_int_handler)
 
         registry = openerp.modules.registry.RegistryManager.get(dbname)
         cr = registry.cursor()


### PR DESCRIPTION
When we call openerp.service.server.start(), it modifies the default signal
handler for SIGINT by its own one which prevent us to SIGINT anthem. This
correction restores the default signal.