### PR TITLE
Disable Odoo's xmlrpc port

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,6 +10,8 @@ Unreleased
 
 **Bugfixes**
 
+* Disable Odoo's xmlrpc port
+
 **Improvements**
 
 **Documentation**

--- a/anthem/cli.py
+++ b/anthem/cli.py
@@ -112,6 +112,8 @@ class Context(object):
     def _build_odoo_env(self, odoo_args):
         odoo.tools.config.parse_config(odoo_args)
         dbname = odoo.tools.config['db_name']
+        odoo.tools.config['workers'] = 0
+        odoo.tools.config['xmlrpc'] = False
         if not dbname:
             argparse.ArgumentParser().error(
                 "please provide a database name though Odoo options (either "


### PR DESCRIPTION
If the configuration file had --workers > 0, Odoo would start the
PreforkServer, which directly opens the xmlrpc port even if not needed.
This commit sets the count of workers to 0, so we force to use the
ThreadedServer (anthem doesn't use more than one worker) and disables
the xmlrpc publishing.