### PR TITLE
Fix define_settings method

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,6 +10,8 @@ Unreleased
 
 **Bugfixes**
 
+* Calling anthem.lyrics.settings.define_settings in 13.0 breaks odoo environment
+
 **Improvements**
 
 **Documentation**

--- a/anthem/lyrics/settings.py
+++ b/anthem/lyrics/settings.py
@@ -3,15 +3,33 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0.en.html)
 
 from past.builtins import basestring
+from ..cli import odoo
 
 
 def define_settings(ctx, model, values):
     """ Define settings like being in the interface
-     Example :
-      - model = 'sale.config.settings' or ctx.env['sale.config.settings']
-      - values = {'default_invoice_policy': 'delivery'}
-     Be careful, settings onchange are not triggered with this function.
+
+    Example:
+
+    model: 'sale.config.settings' or ctx.env['sale.config.settings']
+    values: {'default_invoice_policy': 'delivery'}
+
+    Be careful:
+
+    * settings onchange are not triggered with this function.
+    * in recent versions, the model is always 'res.config.settings'
+    * it cannot be used to install/uninstall modules
     """
     if isinstance(model, basestring):
         model = ctx.env[model]
-    model.create(values).execute()
+    if odoo.release.version_info[0] < 13:
+        # < 13.0, execute takes care of default values, groups,
+        # install/uninstall and call set_values() for the rest.
+        # We don't want the install part, but we need default and groups,
+        # so call execute().
+        model.create(values).execute()
+    else:
+        # In 13.0, execute calls set_values(), then takes care of
+        # install/uninstall. execute() resets the env which breaks
+        # computed fields afterwards, so do not call it.
+        model.create(values).set_values()


### PR DESCRIPTION
In 13.0, the method ResConfigSettings.execute() [0] reset odoo env after
installing/uninstalling addons, after this, computed fields misbehave
(for instance, after a record creation, they would return an empty value
or a CacheMiss)

In 13.0, we can call set_values() which does what we want, before this
version, we have to keep calling execute() (which doesn't have the
mentioned issue) because it sets the default values and the groups.

[0] https://github.com/odoo/odoo/blob/054d4bc6bc219bcc6b0a64265e8d7e9c7423dbc8/odoo/addons/base/models/res_config.py#L633-L637