### PR TITLE
missing argument in uninstall example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -316,7 +316,7 @@ Example (given that there are modules ``foo`` and ``bar`` that you want gone):
   @anthem.log
   def uninstall_foo(ctx):
       """Get rid of legacy `foo` and `bar`."""
-      uninstall(['foo', 'bar'])
+      uninstall(ctx,['foo', 'bar'])
 
 Updating translations on module(s)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
README.RST: example of uninstalling a module has missing context argument, according to definition in anthem/lyrics/modules.py: 
```

def uninstall(ctx, module_list):
    """ uninstall module """
    if not module_list:
        raise AnthemError(u"You have to provide a list of "
                          "module's name to uninstall")

    mods = ctx.env['ir.module.module'].search([('name', 'in', module_list)])
    try:
        mods.button_immediate_uninstall()
    except Exception:
        raise AnthemError(u'Cannot uninstall modules. See the logs')
```
