### PR TITLE
[IMP] Make modules.uninstall idempotent

### DIFF
--- a/anthem/lyrics/modules.py
+++ b/anthem/lyrics/modules.py
@@ -10,7 +10,10 @@ def uninstall(ctx, module_list):
         raise AnthemError("You have to provide a list of " "module's name to uninstall")
 
     mods = ctx.env["ir.module.module"].search(
-        [("name", "in", module_list), ("state", "!=", "uninstalled")]
+        [
+            ("name", "in", module_list),
+            ("state", "not in", ["uninstalled", "uninstallable"]),
+        ]
     )
     try:
         mods.button_immediate_uninstall()


### PR DESCRIPTION
Currently, we're searching for modules no matter their state.
If, for some reason, we run this script twice, we will try to uninstall
already uninstalled modules from the first run, which will crash.

Proposed solution : Search for installed or to update modules only.