### PR TITLE
[IMP] Skip uninstallation of uninstalled modules

### DIFF
--- a/anthem/lyrics/modules.py
+++ b/anthem/lyrics/modules.py
@@ -11,7 +11,9 @@ def uninstall(ctx, module_list):
         raise AnthemError(u"You have to provide a list of "
                           "module's name to uninstall")
 
-    mods = ctx.env['ir.module.module'].search([('name', 'in', module_list)])
+    mods = ctx.env["ir.module.module"].search(
+        [("name", "in", module_list), ("state", "!=", "uninstalled")]
+    )
     try:
         mods.button_immediate_uninstall()
     except Exception:


### PR DESCRIPTION
Useful when running with `MARABUNTA_FORCE_VERSION`.

CC: @JevinD