### PR TITLE
Nuke translations

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -17,6 +17,7 @@ Unreleased
 **Improvements**
 
 - Enable Travis-CI tests for Odoo 14 and Odoo 15
+- Add: nuke_translations to allow to remove already existing translations
 
 **Documentation**
 

--- a/anthem/lyrics/modules.py
+++ b/anthem/lyrics/modules.py
@@ -28,6 +28,7 @@ def update_translations(ctx, module_list, overwrite=False):
         )
     if overwrite:
         ctx.log_line(u"All previous translations will be dropped for requested addons")
+        ctx.nuke_translations(module_list)
     ir_module = ctx.env["ir.module.module"]
     if hasattr(ir_module, "update_translations"):
         # Odoo version <= 10.0
@@ -41,3 +42,12 @@ def update_translations(ctx, module_list, overwrite=False):
     ctx.log_line("Reloading translations for %s" % str(module_list))
     mods.with_context(overwrite=overwrite)
     getattr(mods, method_name)()
+
+
+def nuke_translations(ctx, module_list):
+    """ Remove translations from module list"""
+    if not isinstance(module_list, list):
+        raise AnthemError(
+            u"You have to provide a list of module's name to remove the translations"
+        )
+    ctx.env["ir.translation"].search([("module", "in", module_list)]).unlink()


### PR DESCRIPTION
A lot of time the overwrite parameter is not working.
Nuking them before using the reload works well