### PR TITLE
Fix Update_translation function, remove ctx call on nuke_translation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
           - --remove-duplicate-keys
           - --remove-unused-variables
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 22.3.0
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/mirrors-prettier

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,6 +10,7 @@ Unreleased
 
 **Bugfixes**
 
+- Fix Update_translation function and update black version 22.3.0
 - Pin version of Setuptools < 58
 - Fix environment initialization for Odoo 15
 - Fix `add_xmlid` for Odoo 15

--- a/anthem/lyrics/loaders.py
+++ b/anthem/lyrics/loaders.py
@@ -130,13 +130,13 @@ def load_rows(ctx, model, header, rows):
     result = model.load(header, rows)
     ids = result["ids"]
     if not ids:
-        messages = u"\n".join(u"- %s" % msg for msg in result["messages"])
+        messages = "\n".join("- %s" % msg for msg in result["messages"])
         ctx.log_line(
-            u"Failed to load CSV " u"in '%s'. Details:\n%s" % (model._name, messages)
+            "Failed to load CSV " "in '%s'. Details:\n%s" % (model._name, messages)
         )
-        raise AnthemError(u"Could not import CSV. See the logs")
+        raise AnthemError("Could not import CSV. See the logs")
     else:
-        ctx.log_line(u"Imported %d records in '%s'" % (len(ids), model._name))
+        ctx.log_line("Imported %d records in '%s'" % (len(ids), model._name))
 
 
 def load_csv_stream(ctx, model, data, header=None, header_exclude=None, **fmtparams):
@@ -186,6 +186,6 @@ def update_translations(ctx, module_list):
     """
     modules.update_translations(ctx, module_list)
     ctx.log_line(
-        u"Deprecated: use anthem.lyrics.modules.update_translations"
+        "Deprecated: use anthem.lyrics.modules.update_translations"
         "instead of anthem.lyrics.loaders.update_translations"
     )

--- a/anthem/lyrics/modules.py
+++ b/anthem/lyrics/modules.py
@@ -5,11 +5,9 @@ from ..exceptions import AnthemError
 
 
 def uninstall(ctx, module_list):
-    """ uninstall module """
+    """uninstall module"""
     if not module_list:
-        raise AnthemError(
-            u"You have to provide a list of " "module's name to uninstall"
-        )
+        raise AnthemError("You have to provide a list of " "module's name to uninstall")
 
     mods = ctx.env["ir.module.module"].search(
         [("name", "in", module_list), ("state", "!=", "uninstalled")]
@@ -17,17 +15,17 @@ def uninstall(ctx, module_list):
     try:
         mods.button_immediate_uninstall()
     except Exception:
-        raise AnthemError(u"Cannot uninstall modules. See the logs")
+        raise AnthemError("Cannot uninstall modules. See the logs")
 
 
 def update_translations(ctx, module_list, overwrite=False):
-    """ Update translations from module list"""
+    """Update translations from module list"""
     if not isinstance(module_list, list):
         raise AnthemError(
-            u"You have to provide a list of " "module's name to update the translations"
+            "You have to provide a list of " "module's name to update the translations"
         )
     if overwrite:
-        ctx.log_line(u"All previous translations will be dropped for requested addons")
+        ctx.log_line("All previous translations will be dropped for requested addons")
         nuke_translations(ctx, module_list)
     ir_module = ctx.env["ir.module.module"]
     if hasattr(ir_module, "update_translations"):
@@ -45,9 +43,9 @@ def update_translations(ctx, module_list, overwrite=False):
 
 
 def nuke_translations(ctx, module_list):
-    """ Remove translations from module list"""
+    """Remove translations from module list"""
     if not isinstance(module_list, list):
         raise AnthemError(
-            u"You have to provide a list of module's name to remove the translations"
+            "You have to provide a list of module's name to remove the translations"
         )
     ctx.env["ir.translation"].search([("module", "in", module_list)]).unlink()

--- a/anthem/lyrics/modules.py
+++ b/anthem/lyrics/modules.py
@@ -28,7 +28,7 @@ def update_translations(ctx, module_list, overwrite=False):
         )
     if overwrite:
         ctx.log_line(u"All previous translations will be dropped for requested addons")
-        ctx.nuke_translations(module_list)
+        nuke_translations(ctx, module_list)
     ir_module = ctx.env["ir.module.module"]
     if hasattr(ir_module, "update_translations"):
         # Odoo version <= 10.0

--- a/anthem/lyrics/records.py
+++ b/anthem/lyrics/records.py
@@ -7,7 +7,7 @@ from past.builtins import basestring
 
 
 def add_xmlid(ctx, record, xmlid, noupdate=False):
-    """ Add a XMLID on an existing record """
+    """Add a XMLID on an existing record"""
     ir_model_data = ctx.env["ir.model.data"]
     try:
         if hasattr(ir_model_data, "xmlid_lookup"):
@@ -37,7 +37,7 @@ def add_xmlid(ctx, record, xmlid, noupdate=False):
 
 
 def create_or_update(ctx, model, xmlid, values):
-    """ Create or update a record matching xmlid with values """
+    """Create or update a record matching xmlid with values"""
     if isinstance(model, basestring):
         model = ctx.env[model]
 

--- a/anthem/lyrics/uninstaller.py
+++ b/anthem/lyrics/uninstaller.py
@@ -5,9 +5,9 @@ from . import modules
 
 
 def uninstall(ctx, module_list):
-    """ uninstall module """
+    """uninstall module"""
     modules.uninstall(ctx, module_list)
     ctx.log_line(
-        u"Deprecated: use anthem.lyrics.modules.uninstall instead of "
+        "Deprecated: use anthem.lyrics.modules.uninstall instead of "
         "anthem.lyrics.uninstaller.uninstall"
     )

--- a/anthem/output.py
+++ b/anthem/output.py
@@ -12,7 +12,7 @@ from past.builtins import PY3
 
 
 def safe_print(ustring, errors="replace", **kwargs):
-    """ Safely print a unicode string """
+    """Safely print a unicode string"""
     encoding = sys.stdout.encoding or "utf-8"
     if PY3:
         print(ustring, **kwargs)
@@ -27,29 +27,29 @@ class LogIndent(object):
 
     @contextmanager
     def display(self, name, timing=True, timestamp=False):
-        self.print_indent(u"{}...".format(name), timestamp=timestamp)
+        self.print_indent("{}...".format(name), timestamp=timestamp)
         self.level += 1
         start = time.time()
         try:
             yield
         except Exception:
             self.level -= 1
-            self.print_indent(u"{}: error".format(name), timestamp=timestamp)
+            self.print_indent("{}: error".format(name), timestamp=timestamp)
             raise
         end = time.time()
         self.level -= 1
         if timing:
             self.print_indent(
-                u"{}: {:.3f}s".format(name, end - start), timestamp=timestamp
+                "{}: {:.3f}s".format(name, end - start), timestamp=timestamp
             )
 
     def print_indent(self, message, timestamp=False):
         if not timestamp:
-            safe_print(u"{}{}".format(u"    " * self.level, message))
+            safe_print("{}{}".format("    " * self.level, message))
         else:
             safe_print(
-                u"{}{}: {}".format(
-                    u"    " * self.level, time.strftime("%Y-%m-%d %H:%M:%S"), message
+                "{}{}: {}".format(
+                    "    " * self.level, time.strftime("%Y-%m-%d %H:%M:%S"), message
                 )
             )
 

--- a/tests/test_lyrics_loaders.py
+++ b/tests/test_lyrics_loaders.py
@@ -56,7 +56,7 @@ def test_load_csv_file_model(tmpdir):
 
 
 def test_load_csv_stream_model_string():
-    """ Pass string instead of model to load_csv_stream """
+    """Pass string instead of model to load_csv_stream"""
     csv_stream = BytesIO()
     csv_stream.write(csv_partner)
     csv_stream.seek(0)


### PR DESCRIPTION
Fix update translation function. when it's called with the parameters overwrite=True, the function call the nuke_translations function of the context. remove the context to call the correct function nuke.